### PR TITLE
Avoid initialize error on Tensorflow v1.13.1

### DIFF
--- a/AdaBound.py
+++ b/AdaBound.py
@@ -120,7 +120,6 @@ class AdaBoundOptimizer(optimizer.Optimizer):
         return control_flow_ops.group(*[var_update, m_t, v_t, vhat_t])
 
     def _resource_apply_dense(self, grad, var):
-        var = var.handle
         beta1_power = math_ops.cast(self._beta1_power, grad.dtype.base_dtype)
         beta2_power = math_ops.cast(self._beta2_power, grad.dtype.base_dtype)
         lr_t = math_ops.cast(self._lr_t, grad.dtype.base_dtype)
@@ -136,17 +135,17 @@ class AdaBoundOptimizer(optimizer.Optimizer):
         upper_bound = final_lr * (1. + 1. / (gamma_multi))
 
         # m_t = beta1 * m + (1 - beta1) * g_t
-        m = self.get_slot(var, "m").handle
+        m = self.get_slot(var, "m")
         m_scaled_g_values = grad * (1 - beta1_t)
         m_t = state_ops.assign(m, beta1_t * m + m_scaled_g_values, use_locking=self._use_locking)
 
         # v_t = beta2 * v + (1 - beta2) * (g_t * g_t)
-        v = self.get_slot(var, "v").handle
+        v = self.get_slot(var, "v")
         v_scaled_g_values = (grad * grad) * (1 - beta2_t)
         v_t = state_ops.assign(v, beta2_t * v + v_scaled_g_values, use_locking=self._use_locking)
 
         # amsgrad
-        vhat = self.get_slot(var, "vhat").handle
+        vhat = self.get_slot(var, "vhat")
         if self._amsbound:
             vhat_t = state_ops.assign(vhat, math_ops.maximum(v_t, vhat))
             v_sqrt = math_ops.sqrt(vhat_t)
@@ -216,7 +215,7 @@ class AdaBoundOptimizer(optimizer.Optimizer):
 
     def _resource_scatter_add(self, x, i, v):
         with ops.control_dependencies(
-                [resource_variable_ops.resource_scatter_add(x.handle, i, v)]):
+                [resource_variable_ops.resource_scatter_add(x, i, v)]):
             return x.value()
 
     def _resource_apply_sparse(self, grad, var, indices):

--- a/AdaBound.py
+++ b/AdaBound.py
@@ -47,21 +47,24 @@ class AdaBoundOptimizer(optimizer.Optimizer):
         self._beta2_t = None
         self._epsilon_t = None
 
-        self._beta1_power = None
-        self._beta2_power = None
-
     def _create_slots(self, var_list):
         first_var = min(var_list, key=lambda x: x.name)
 
-        create_new = self._beta1_power is None
+        graph = None if context.executing_eagerly() else ops.get_default_graph()
+        create_new = self._get_non_slot_variable("beta1_power", graph) is None
         if not create_new and context.in_graph_mode():
-            create_new = (self._beta1_power.graph is not first_var.graph)
+            create_new = (self._get_non_slot_variable("beta1_power", graph).graph is not first_var.graph)
 
         if create_new:
-            with ops.colocate_with(first_var):
-                self._beta1_power = variable_scope.variable(self._beta1, name="beta1_power", trainable=False)
-                self._beta2_power = variable_scope.variable(self._beta2, name="beta2_power", trainable=False)
-                self._gamma_multi = variable_scope.variable(self._gamma, name="gamma_multi", trainable=False)
+            self._create_non_slot_variable(initial_value=self._beta1,
+                                           name="beta1_power",
+                                           colocate_with=first_var)
+            self._create_non_slot_variable(initial_value=self._beta2,
+                                           name="beta2_power",
+                                           colocate_with=first_var)
+            self._create_non_slot_variable(initial_value=self._gamma,
+                                           name="gamma_multi",
+                                           colocate_with=first_var)
         # Create slots for the first and second moments.
         for v in var_list :
             self._zeros_slot(v, "m", self._name)
@@ -78,14 +81,15 @@ class AdaBoundOptimizer(optimizer.Optimizer):
         self._gamma_t = ops.convert_to_tensor(self._gamma)
 
     def _apply_dense(self, grad, var):
-        beta1_power = math_ops.cast(self._beta1_power, var.dtype.base_dtype)
-        beta2_power = math_ops.cast(self._beta2_power, var.dtype.base_dtype)
+        graph = None if context.executing_eagerly() else ops.get_default_graph()
+        beta1_power = math_ops.cast(self._get_non_slot_variable("beta1_power", graph=graph), var.dtype.base_dtype)
+        beta2_power = math_ops.cast(self._get_non_slot_variable("beta2_power", graph=graph), var.dtype.base_dtype)
         lr_t = math_ops.cast(self._lr_t, var.dtype.base_dtype)
         base_lr_t = math_ops.cast(self._base_lr_t, var.dtype.base_dtype)
         beta1_t = math_ops.cast(self._beta1_t, var.dtype.base_dtype)
         beta2_t = math_ops.cast(self._beta2_t, var.dtype.base_dtype)
         epsilon_t = math_ops.cast(self._epsilon_t, var.dtype.base_dtype)
-        gamma_multi = math_ops.cast(self._gamma_multi, var.dtype.base_dtype)
+        gamma_multi = math_ops.cast(self._get_non_slot_variable("gamma_multi", graph=graph), var.dtype.base_dtype)
 
         step_size = (lr_t * math_ops.sqrt(1 - beta2_power) / (1 - beta1_power))
         final_lr = self._final_lr * lr_t / base_lr_t
@@ -120,14 +124,15 @@ class AdaBoundOptimizer(optimizer.Optimizer):
         return control_flow_ops.group(*[var_update, m_t, v_t, vhat_t])
 
     def _resource_apply_dense(self, grad, var):
-        beta1_power = math_ops.cast(self._beta1_power, grad.dtype.base_dtype)
-        beta2_power = math_ops.cast(self._beta2_power, grad.dtype.base_dtype)
+        graph = None if context.executing_eagerly() else ops.get_default_graph()
+        beta1_power = math_ops.cast(self._get_non_slot_variable("beta1_power", graph=graph), grad.dtype.base_dtype)
+        beta2_power = math_ops.cast(self._get_non_slot_variable("beta2_power", graph=graph), grad.dtype.base_dtype)
         lr_t = math_ops.cast(self._lr_t, grad.dtype.base_dtype)
         base_lr_t = math_ops.cast(self._base_lr_t, var.dtype.base_dtype)
         beta1_t = math_ops.cast(self._beta1_t, grad.dtype.base_dtype)
         beta2_t = math_ops.cast(self._beta2_t, grad.dtype.base_dtype)
         epsilon_t = math_ops.cast(self._epsilon_t, grad.dtype.base_dtype)
-        gamma_multi = math_ops.cast(self._gamma_multi, var.dtype.base_dtype)
+        gamma_multi = math_ops.cast(self._get_non_slot_variable("gamma_multi", graph=graph), var.dtype.base_dtype)
 
         step_size = (lr_t * math_ops.sqrt(1 - beta2_power) / (1 - beta1_power))
         final_lr = self._final_lr * lr_t / base_lr_t
@@ -162,8 +167,9 @@ class AdaBoundOptimizer(optimizer.Optimizer):
         return control_flow_ops.group(*[var_update, m_t, v_t, vhat_t])
 
     def _apply_sparse_shared(self, grad, var, indices, scatter_add):
-        beta1_power = math_ops.cast(self._beta1_power, var.dtype.base_dtype)
-        beta2_power = math_ops.cast(self._beta2_power, var.dtype.base_dtype)
+        graph = None if context.executing_eagerly() else ops.get_default_graph()
+        beta1_power = math_ops.cast(self._get_non_slot_variable("beta1_power", graph=graph), var.dtype.base_dtype)
+        beta2_power = math_ops.cast(self._get_non_slot_variable("beta2_power", graph=graph), var.dtype.base_dtype)
         lr_t = math_ops.cast(self._lr_t, var.dtype.base_dtype)
         base_lr_t = math_ops.cast(self._base_lr_t, var.dtype.base_dtype)
         beta1_t = math_ops.cast(self._beta1_t, var.dtype.base_dtype)
@@ -225,15 +231,19 @@ class AdaBoundOptimizer(optimizer.Optimizer):
     def _finish(self, update_ops, name_scope):
         # Update the power accumulators.
         with ops.control_dependencies(update_ops):
-            with ops.colocate_with(self._beta1_power):
-                update_beta1 = self._beta1_power.assign(
-                    self._beta1_power * self._beta1_t,
+            graph = None if context.executing_eagerly() else ops.get_default_graph()
+            beta1_power = self._get_non_slot_variable("beta1_power", graph=graph)
+            beta2_power = self._get_non_slot_variable("beta2_power", graph=graph)
+            gamma_multi = self._get_non_slot_variable("gamma_multi", graph=graph)
+            with ops.colocate_with(beta1_power):
+                update_beta1 = beta1_power.assign(
+                    beta1_power * self._beta1_t,
                     use_locking=self._use_locking)
-                update_beta2 = self._beta2_power.assign(
-                    self._beta2_power * self._beta2_t,
+                update_beta2 = beta2_power.assign(
+                    beta2_power * self._beta2_t,
                     use_locking=self._use_locking)
-                update_gamma = self._gamma_multi.assign(
-                    self._gamma_multi + self._gamma_t,
+                update_gamma = gamma_multi.assign(
+                    gamma_multi + self._gamma_t,
                     use_locking=self._use_locking)
         return control_flow_ops.group(*update_ops + [update_beta1, update_beta2, update_gamma],
                                       name=name_scope)


### PR DESCRIPTION
I'm using Tensorflow v1.13.1, so I checked #3 and avoid the error by [joeyearsley's comment](https://github.com/taki0112/AdaBound-Tensorflow/issues/3#issuecomment-471576005).
Still, I encountered another error as following.
```
Traceback (most recent call last):
  File "run_unet_3d.py", line 118, in <module>
    main(args)
  File "run_unet_3d.py", line 114, in main
    epochs=25, shuffle=False)
  File "/home/user/anaconda3/lib/python3.6/site-packages/tensorflow/python/keras/engine/training.py", line 1426, in fit_generator
    initial_epoch=initial_epoch)
  File "/home/user/anaconda3/lib/python3.6/site-packages/tensorflow/python/keras/engine/training_generator.py", line 191, in model_iteration
    batch_outs = batch_function(*batch_data)
  File "/home/user/anaconda3/lib/python3.6/site-packages/tensorflow/python/keras/engine/training.py", line 1191, in train_on_batch
    outputs = self._fit_function(ins)  # pylint: disable=not-callable
  File "/home/user/anaconda3/lib/python3.6/site-packages/tensorflow/python/keras/backend.py", line 3076, in __call__
    run_metadata=self.run_metadata)
  File "/home/user/anaconda3/lib/python3.6/site-packages/tensorflow/python/client/session.py", line 1439, in __call__
    run_metadata_ptr)
  File "/home/user/anaconda3/lib/python3.6/site-packages/tensorflow/python/framework/errors_impl.py", line 528, in __exit__
    c_api.TF_GetCode(self.status.status))
tensorflow.python.framework.errors_impl.FailedPreconditionError: Attempting to use uninitialized value training/TFOptimizer/beta1_power
         [[{{node training/TFOptimizer/beta1_power/read}}]]
         [[{{node metrics/bg_probability_dice/div_no_nan}}]]
```
This shows non train values(non slots) are uninitialized.
To add `tf.global_variables_initializer().run()` after creation of non train variables in `_create_slots()` avoid this error, but my pull request would be more smart.

Thank you.